### PR TITLE
Generate a dummy ETL script

### DIFF
--- a/mozreport/cli.py
+++ b/mozreport/cli.py
@@ -11,7 +11,7 @@ import click
 import toml
 
 from .databricks import DatabricksConfig
-from .experiment import ExperimentConfig
+from .experiment import ExperimentConfig, generate_etl_script
 
 
 @attr.s()
@@ -151,3 +151,8 @@ def new():
         pass
     experiment_config = build_experiment_config(experiment_config)
     experiment_config.save()
+
+    click.echo("Writing ETL script to mozreport_etl_script.py...")
+    script = generate_etl_script(experiment_config)
+    with open("mozreport_etl_script.py", "w") as f:
+        f.write(script)

--- a/mozreport/etl_script.py
+++ b/mozreport/etl_script.py
@@ -1,0 +1,34 @@
+# This is a script for computing the core product metrics for an experiment.
+
+import json
+import os
+
+# BEGIN_BLOB
+blob = """
+{
+    "slug": "test-slug-123",
+    "uuid": "test-uuid",
+    "branches": [
+        "control",
+        "experiment"
+    ]
+}
+""".strip()
+# END_BLOB
+
+
+def run_etl(root="/"):
+    config = json.loads(blob)
+    output_path = os.path.join(
+        root,
+        "dbfs",
+        "mozreport",
+        "%s-%s" % (config["slug"], config["uuid"]),
+        "summary.csv")
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, "wt") as f:
+        f.write(blob)
+
+
+if __name__ == "__main__":
+    run_etl()

--- a/mozreport/experiment.py
+++ b/mozreport/experiment.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 from typing import List, Optional
 
 import attr
@@ -29,3 +30,16 @@ class ExperimentConfig:
         config_path.parent.mkdir(parents=True, exist_ok=True)
         with open(config_path, "w") as f:
             toml.dump(d, f)
+
+
+def generate_etl_script(experiment_config):
+    etl_script_path = Path(__file__).parent/"etl_script.py"
+    etl_script = etl_script_path.read_text()
+    blob = cattr.unstructure(experiment_config)
+    etl_script = re.sub(
+        r"^# BEGIN_BLOB.*# END_BLOB",
+        f'blob = """{blob}"""',
+        etl_script,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    return etl_script

--- a/mozreport/tests/test_experiment.py
+++ b/mozreport/tests/test_experiment.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import pytest
 
-from mozreport.experiment import ExperimentConfig
+from mozreport.experiment import ExperimentConfig, generate_etl_script
 
 
 class TestExperimentConfig:
@@ -33,3 +33,9 @@ class TestExperimentConfig:
     def test_creates_intermediate_path(self, tmpdir, config):
         filename = Path(tmpdir.join("foo", "bar", "config.toml"))
         config.save(filename)
+
+    def test_config_injection(self, config):
+        generated = generate_etl_script(config)
+        assert "experiment-uuid" in generated
+        # Test that the generated code doesn't throw a syntax error
+        compile(generated, "<string>", mode="exec")


### PR DESCRIPTION
Stand-in for testing and further development; eventually this should
a) do something useful, and
b) be unit-tested.

Injecting a JSON blob is hacky, but avoids requiring additional dependencies on Databricks.