### PR TITLE
Tear branches out of the saved config

### DIFF
--- a/mozreport/cli.py
+++ b/mozreport/cli.py
@@ -1,4 +1,3 @@
-from itertools import chain, repeat
 from pathlib import Path
 import sys
 from typing import Optional, Union
@@ -129,16 +128,6 @@ def build_experiment_config(defaults: Optional[Union[dict, ExperimentConfig]]) -
         type=str,
         default=defaults.get("slug", None)
     )
-
-    default_n = len(defaults["branches"]) if "branches" in defaults else 2
-    n_branches = click.prompt("Number of branches", default=default_n)
-
-    branchiter = chain(defaults.get("branches", []), repeat(None))
-    branches = []
-    for i, branchname in zip(range(n_branches), branchiter):
-        branches.append(click.prompt(f"Branch {i+1}", type=str, default=branchname))
-
-    args["branches"] = branches
 
     return cattr.structure(args, ExperimentConfig)
 

--- a/mozreport/etl_template/etl_script.py
+++ b/mozreport/etl_template/etl_script.py
@@ -30,6 +30,7 @@ def run_etl(slug, enrollment_end, output_path):
       metrics.EngagementIntensity,
     ]
 
+    spark.conf.set("spark.databricks.queryWatchdog.enabled", False)  # noqa
     experiments = spark.table("experiments")  # noqa
     my_experiment = experiments.filter(experiments.experiment_id == slug)
     if enrollment_end:

--- a/mozreport/etl_template/etl_script.py
+++ b/mozreport/etl_template/etl_script.py
@@ -18,7 +18,7 @@ def name_to_stub(name):
     return re.sub(r"[^A-Za-z0-9]+", "_", name).strip("_").lower()
 
 
-def run_etl(slug, branches, enrollment_end, output_path):
+def run_etl(slug, enrollment_end, output_path):
     from mozanalysis import metrics
     from mozanalysis.experiments import ExperimentAnalysis
     from pyspark.sql import functions as f
@@ -78,12 +78,11 @@ def run_etl(slug, branches, enrollment_end, output_path):
 
 
 @click.command()
-@click.option("--branch", "branches", multiple=True, required=True, type=str)
 @click.option("--slug", required=True, type=str)
 @click.option("--uuid", required=True, type=str)
 @click.option("--enrollment-end", type=str)
 @click.option("--test", is_flag=True)
-def cli(slug, uuid, branches, enrollment_end, test):
+def cli(slug, uuid, enrollment_end, test):
     safe_slug = name_to_stub(slug)
     output_path = os.path.join(
         "/",
@@ -95,10 +94,9 @@ def cli(slug, uuid, branches, enrollment_end, test):
     if test:
         print("Slug:", slug)
         print("Last day of enrollment period:", enrollment_end)
-        print("Branches:", branches)
         print("Output path:", output_path)
         sys.exit(0)
-    run_etl(slug, branches, enrollment_end, output_path)
+    run_etl(slug, enrollment_end, output_path)
 
 
 if __name__ == "__main__":

--- a/mozreport/experiment.py
+++ b/mozreport/experiment.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 import attr
 import cattr
@@ -13,7 +13,6 @@ from .util import name_to_stub
 class ExperimentConfig:
     uuid: str = attr.ib()
     slug: str = attr.ib()
-    branches: List[str] = attr.ib()
 
     @staticmethod
     def _default_config_path():
@@ -57,8 +56,6 @@ def submit_etl_script(
         client.delete_file(etl_script_destination)
     client.upload_file(etl_script, etl_script_destination)
     params = ["--slug", experiment.slug, "--uuid", experiment.uuid]
-    for branch in experiment.branches:
-        params.extend(["--branch", branch])
     job_id = client.submit_python_task(
         experiment.slug,
         cluster_slug,

--- a/mozreport/tests/test_cli.py
+++ b/mozreport/tests/test_cli.py
@@ -12,7 +12,7 @@ from mozreport.experiment import ExperimentConfig
 def write_config_files():
     databricks = DatabricksConfig(host="foo", token="bar")
     cliconfig = cli.CliConfig(default_template="rmarkdown", databricks=databricks)
-    experiment = ExperimentConfig(uuid="monty", slug="camelot", branches=["spam", "eggs"])
+    experiment = ExperimentConfig(uuid="monty", slug="camelot")
     cliconfig.save(Path("config.toml"))
     experiment.save()
 

--- a/mozreport/tests/test_databricks.py
+++ b/mozreport/tests/test_databricks.py
@@ -46,6 +46,7 @@ class TestDatabricksIntegration:
         test_script = dedent("""\
             import sys
             output_path = sys.argv[1]
+            spark.conf.set("spark.databricks.queryWatchdog.enabled", False)
             colnames = spark.table("main_summary").columns
             with open(output_path, "w") as f:
                 f.write(repr(colnames))

--- a/mozreport/tests/test_experiment.py
+++ b/mozreport/tests/test_experiment.py
@@ -10,10 +10,6 @@ class TestExperimentConfig:
         return ExperimentConfig(
             uuid="experiment-uuid",
             slug="experiment-slug",
-            branches=[
-                "control",
-                "experimental",
-            ]
         )
 
     def test_writes_tempfile(self, tmpdir, config):


### PR DESCRIPTION
We'll always just learn branches from the data. If branches are
allocated in a particular ratio, we can learn that from Normandy and
feed it to the analysis script; nothing else needs to care about it.