### PR TITLE
Fix fake Databricks failures by avoiding SystemExit

### DIFF
--- a/mozreport/etl_template/etl_script.py
+++ b/mozreport/etl_template/etl_script.py
@@ -101,5 +101,4 @@ def cli(slug, uuid, enrollment_end, test):
 
 
 if __name__ == "__main__":
-    cli()
-    sys.exit(0)
+    cli(standalone_mode=False)


### PR DESCRIPTION
Databricks jobs appear to fail when the called scripts terminate with
any exception, up to and including SystemExit, even when the error level
is 0.

Setting `standalone_mode` has two main effects:
* The function terminates with a `return` instead of a `sys.exit()`
* Exceptions are propagated instead of captured and printed

We care about the former.

Ref: https://github.com/pallets/click/blob/38a2712d596a5df9288c1817748b71197d8c7c57/click/core.py#L680-L688