### PR TITLE
Add support for chaining commands together/pipelining

### DIFF
--- a/mozreport/cli.py
+++ b/mozreport/cli.py
@@ -43,7 +43,12 @@ cli.__doc__ = f"""
     \b
     The local configuration directory is {get_data_dir()}.
 """
-cli = click.group()(cli)
+cli = click.group(
+        context_settings={
+            "help_option_names": ["-h", "--help"],
+            "max_content_width": 120,
+        },
+    )(cli)
 
 
 @attr.s()

--- a/mozreport/cli.py
+++ b/mozreport/cli.py
@@ -181,7 +181,8 @@ def setup():
 
 
 @cli.command()
-def new():
+@click.pass_context
+def new(ctx):
     """Begin a new experiment analysis.
     """
     experiment_config = None
@@ -196,6 +197,17 @@ def new():
     script = generate_etl_script(experiment_config)
     with open("mozreport_etl_script.py", "w") as f:
         f.write(script)
+
+    if click.confirm(
+            "Would you like to submit the default script to shared_serverless now?",
+            default=True,
+            ):
+        ctx.invoke(submit)
+    else:
+        click.echo(
+            "You can edit `mozreport_etl_script.py` to customize the analysis, "
+            "and then run `mozreport submit` whenever you're ready to continue."
+        )
 
 
 @cli.command()

--- a/mozreport/cli.py
+++ b/mozreport/cli.py
@@ -267,7 +267,7 @@ def submit(ctx, cluster_slug, wait, filename):
     if not wait:
         return
     with Spinner(text="Waiting for completion") as spinner:
-        state = None
+        state = status["state"]["life_cycle_state"]
         while state != "TERMINATED":
             time.sleep(5)
             status = client.run_info(run_id)

--- a/mozreport/tests/test_cli.py
+++ b/mozreport/tests/test_cli.py
@@ -49,7 +49,7 @@ class TestCli:
 
             result = runner.invoke(
                 cli.cli,
-                ["new"],
+                ["--pipeline=never", "new"],
                 input=input,
             )
             assert result.exit_code == 0
@@ -58,7 +58,7 @@ class TestCli:
 
             result2 = runner.invoke(
                 cli.cli,
-                ["new"],
+                ["--pipeline=never", "new"],
                 input=input2,
             )
             assert result2.exit_code == 0
@@ -83,7 +83,11 @@ class TestCli:
             write_config_files()
             with open("mozreport_etl_script.py", "x") as f:
                 f.write("dummy file")
-            result = runner.invoke(cli.cli, ["submit"], env={"MOZREPORT_CONFIG": tmpdir})
+            result = runner.invoke(
+                cli.cli,
+                ["--pipeline=never", "submit"],
+                env={"MOZREPORT_CONFIG": tmpdir}
+            )
         assert result.exit_code == 0
 
     def test_fetch(self, runner, monkeypatch):

--- a/mozreport/tests/test_cli.py
+++ b/mozreport/tests/test_cli.py
@@ -118,6 +118,34 @@ class TestCli:
                 assert f.read() == response
         assert result.exit_code == 0
 
+    def test_pipeline_prompt_yes(self, runner, mock_client):
+        input = "\n" * 100
+        response = mock_client.return_value.get_file.return_value
+        with runner.isolated_filesystem() as tmpdir:
+            write_config_files()
+            result = runner.invoke(
+                cli.cli,
+                ["--pipeline=prompt", "new"],
+                env={"MOZREPORT_CONFIG": tmpdir},
+                input=input,
+            )
+            with open("summary.sqlite3", "rb") as f:
+                assert f.read() == response
+        assert result.exit_code == 0
+
+    def test_pipeline_prompt_no(self, runner, mock_client):
+        input = "n\n" * 100
+        with runner.isolated_filesystem() as tmpdir:
+            write_config_files()
+            result = runner.invoke(
+                cli.cli,
+                ["--pipeline=prompt", "new"],
+                env={"MOZREPORT_CONFIG": tmpdir},
+                input=input,
+            )
+            assert not (Path(tmpdir)/"summary.sqlite3").exists()
+        assert result.exit_code == 0
+
     def test_report(self, runner):
         with runner.isolated_filesystem() as tmpdir:
             write_config_files()


### PR DESCRIPTION
By default, `new` and `submit` prompt to automatically continue
(to `submit` and `fetch`, respectively)
with the default options.

This adds a new `--pipeline=[always|never|prompt]` option to mozreport
to control this behavior globally; the default is prompt.