### PR TITLE
Make sure click is installed in ETL

### DIFF
--- a/mozreport/etl_template/etl_script.py
+++ b/mozreport/etl_template/etl_script.py
@@ -7,7 +7,9 @@ import sqlite3
 import sys
 import tempfile
 
-import click
+dbutils.library.installPyPI("click")  # noqa:F821 unknown name dbutils
+
+import click  # noqa:E402 import not at top of file
 
 
 def name_to_stub(name):


### PR DESCRIPTION
It's possible that click doesn't exist on the target cluster. Use the
dbutils.library API to make sure that it really does.